### PR TITLE
fix "function: not found" error

### DIFF
--- a/ss14.sh
+++ b/ss14.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 RED='\033[0;31m'


### PR DESCRIPTION
you need `bash` to use functions.